### PR TITLE
Add pubmed id to study.txt

### DIFF
--- a/idr0051-study.txt
+++ b/idr0051-study.txt
@@ -17,7 +17,7 @@ Study External URL	# if there is an existing web page related to the study enter
 Study Public Release Date	22/10/2018			
 				
 # Study Publication				
-Study PubMed ID				
+Study PubMed ID	30333213			
 Study Publication Title	Neuromesodermal Progenitors are a Conserved Source of Spinal Cord with Divergent Growth Dynamics			
 Study Author List	"Andrea Attardi, Timothy Fulton, Maria Florescu, Gopi Shah, Leila Muresan, Martin O. Lenz, Courtney Lancaster, Jan Huisken, Alexander van Oudenaarden and Benjamin Steventon"			
 Study PMC ID				

--- a/idr0051-study.txt
+++ b/idr0051-study.txt
@@ -5,7 +5,7 @@
 				
 Comment[IDR Study Accession]	idr0051			
 Study Title	In Toto Cell Tracking using Lightsheet Microscopy of the Neuromesodermal Progenitor Zone of the Zebrafish Tailbud from the 21st Somite Stage			
-Study Type	# leave blank			
+Study Type	light sheet microscopy of zebrafish tailbud			
 Study Type Term Source REF	# leave blank			
 Study Type Term Accession	# leave blank			
 Study Description	Lightsheet microscopy has been previously used to image and directly study the process of gastrulation in a zebrafish embryo. Before now it was not possible to use this method to study late-stage somatogenesis, due to the movement of the embryo, resulting in displacement from the field of view. Here we achieve 4D lightsheet imaging with online, image based registration to maintain the field of view during long timelapses, with emphasis on the tailbud. The zebrafish tailbud is of special interest as it contains a population of bipotent progenitor cells, neuromesodermal progenitors (NMps), competent to enter either the mesodermal or neural lineages. This dataset provides in toto tracking of the tailbud of the developing zebrafish whilst also demonstrating the potential of online tracking during developing to maintain high magnification images whilst tracking a growing object.		 	

--- a/idr0051-study.txt
+++ b/idr0051-study.txt
@@ -20,7 +20,7 @@ Study Public Release Date	22/10/2018
 Study PubMed ID	30333213			
 Study Publication Title	Neuromesodermal Progenitors are a Conserved Source of Spinal Cord with Divergent Growth Dynamics			
 Study Author List	"Andrea Attardi, Timothy Fulton, Maria Florescu, Gopi Shah, Leila Muresan, Martin O. Lenz, Courtney Lancaster, Jan Huisken, Alexander van Oudenaarden and Benjamin Steventon"			
-Study PMC ID				
+Study PMC ID	PMC6240315			
 Study DOI	https://doi.org/10.1242/dev.166728			
 				
 # Study Contacts				


### PR DESCRIPTION
Just adds the pubmed to the study.txt. `study type` is still missing, but I assume that's correct.
/cc @sbesson 